### PR TITLE
Setting "shell: bash"

### DIFF
--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Build
         run: cargo build --release
       - name: Unit tests
-        run: |
-          cargo test --lib --bins --all-features --no-fail-fast --release 2>&1 | tee unit_tests_output.txt
+        shell: bash
+        run: cargo test --lib --bins --all-features --no-fail-fast --release 2>&1 | tee unit_tests_output.txt
       - name: Integration tests
-        run: |
-          cargo test --test '*' --all-features --no-fail-fast --release 2>&1 | tee integration_tests_output.txt
+        shell: bash
+        run: cargo test --test '*' --all-features --no-fail-fast --release 2>&1 | tee integration_tests_output.txt
       - name: Upload Unit Test Output
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CI-e2e-test.yml
+++ b/.github/workflows/CI-e2e-test.yml
@@ -54,6 +54,7 @@ jobs:
 
       # Ready to run the test suite: this calls test_runner.sh script after installing the required dependencies
       - name: Run end-to-end tests
+        shell: bash
         run: yarn test 2>&1 | tee e2e_test_output.txt
         working-directory: ./e2e-tests
 

--- a/.github/workflows/CI-lint-format.yml
+++ b/.github/workflows/CI-lint-format.yml
@@ -39,6 +39,7 @@ jobs:
             rustup target add wasm32-unknown-unknown
             rustup component add rust-src
       - name: Linting
+        shell: bash
         run: cargo clippy --release -- --deny warnings 2>&1 | tee linting_output.txt
       - name: Upload Linting Output
         uses: actions/upload-artifact@v4
@@ -50,6 +51,7 @@ jobs:
           compression-level: 0
           overwrite: true
       - name: Formatting
+        shell: bash
         run: cargo fmt --check 2>&1 | tee formatting_output.txt
       - name: Upload Formatting Output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Since the Orchestrator PR, the CI is silencing errors coming from following workflows:

```
CI-build-test.yml
CI-e2e-test.yml
CI-lint-format.yml
```

This wrong behavior is due to the critical steps being piped with `tee` command:

```
cargo test --lib --bins --all-features --no-fail-fast --release 2>&1 | tee unit_tests_output.txt
cargo test --test '*' --all-features --no-fail-fast --release 2>&1 | tee integration_tests_output.txt
yarn test 2>&1 | tee e2e_test_output.txt
cargo clippy --release -- --deny warnings 2>&1 | tee linting_output.txt
cargo fmt --check 2>&1 | tee formatting_output.txt
```

resulting in pipe exit code being equal to `tee` exit code (`0`, always success), hence suppressing possible failure exit code of the first command.

The solution is to set option `set -o pipefail`; in GitHubActions this can be achieved setting `shell: bash` for the target step ([reference](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)).