### PR TITLE
Update GRANDPA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "sc-consensus-babe",
  "sc-consensus-babe-rpc",
  "sc-consensus-grandpa",
+ "sc-consensus-grandpa-rpc",
  "sc-executor",
  "sc-network",
  "sc-offchain",
@@ -6906,6 +6907,27 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-consensus-grandpa-rpc"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a173af14cfdf8bb5ac073261ca09292a1e9534c815532e34180aee8a9417804"
+dependencies = [
+ "finality-grandpa",
+ "futures",
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-consensus-grandpa",
+ "sc-rpc",
+ "serde",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ sc-consensus-babe = { version = "0.33.0" }
 sc-consensus-babe-rpc = { version = "0.33.0" }
 sc-consensus = { version = "0.32.0" }
 sc-consensus-grandpa = { version = "0.18.0" }
+sc-consensus-grandpa-rpc = { version = "0.18.0" }
 sc-client-api = { version = "27.0.0" }
 sc-sysinfo = { version = "26.0.0" }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -37,6 +37,7 @@ sc-consensus-babe-rpc = { workspace = true }
 sp-consensus-babe = { workspace = true }
 sc-consensus = { workspace = true }
 sc-consensus-grandpa = { workspace = true }
+sc-consensus-grandpa-rpc = { workspace = true }
 sp-consensus-grandpa = { workspace = true }
 sc-client-api = { workspace = true }
 sp-runtime = { workspace = true }


### PR DESCRIPTION
This PR does two things.
First it updates the GRANDPA configuration with safer parameters:
- `gossip_duration` is increased to account for bigger network latencies
- `voting_rule` is set to avoid finalizing blocks with higher probability of being reorganized

Second, it integrates the GRANDPA rpc, so that GRANDPA related functions are available on the RPC interface.