### PR TITLE
Telemetry update

### DIFF
--- a/node/chain-specs/zkverify_testnet.json
+++ b/node/chain-specs/zkverify_testnet.json
@@ -12,7 +12,7 @@
   ],
   "telemetryEndpoints": [
     [
-      "/dns/nh-telemetry.horizenlabs.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      "/dns/testnet-telemetry.zkverify.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
       1
     ]
   ],

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -30,7 +30,7 @@ const BOOTNODE_2_DNS: &str = "bootnode-tn-2.zkverify.io";
 const BOOTNODE_2_PEER_ID: &str = "12D3KooWEjVadU1YWyfDGvyRXPbCq2rXhzJtXaG4RxJZBkGE9Aug";
 
 // The URL for the telemetry server.
-const STAGING_TELEMETRY_URL: &str = "wss://nh-telemetry.horizenlabs.io/submit/";
+const STAGING_TELEMETRY_URL: &str = "wss://testnet-telemetry.zkverify.io/submit/";
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
@@ -187,6 +187,7 @@ pub fn testnet_config() -> Result<ChainSpec, String> {
 }
 
 /// To be used when building new testnet chain-spec
+#[allow(dead_code)]
 pub fn testnet_config_build() -> Result<ChainSpec, String> {
     Ok(ChainSpec::builder(
         WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -55,7 +55,6 @@ impl SubstrateCli for Cli {
         Ok(match id {
             "dev" => Box::new(chain_spec::development_config()?),
             "local" => Box::new(chain_spec::local_config()?),
-            "test_build" => Box::new(chain_spec::testnet_config_build()?),
             "" | "test" => Box::new(chain_spec::testnet_config()?),
             path => Box::new(chain_spec::ChainSpec::from_json_file(
                 std::path::PathBuf::from(path),


### PR DESCRIPTION
Since we would never generate a new chain spec file from scratch (apart from the case of a chain full regenesis), the associated interface has been removed. This was done also to avoid confusion, but the underlying code is kept as dead code (we can also remove it if we prefer).