### PR TITLE
Increased pubs max size, moved from constants to pallet configuration

### DIFF
--- a/pallets/settlement-risc0/src/lib.rs
+++ b/pallets/settlement-risc0/src/lib.rs
@@ -27,10 +27,6 @@ mod tests;
 mod weight;
 
 pub use weight::WeightInfo;
-pub const MAX_PROOF_SIZE: u32 = 1000000; // arbitrary length
-pub const MAX_PUBS_SIZE: u32 = 8 + 4 + 32 * 64; // 8: for bincode::serialize,
-                                                // 4: bytes for payload length,
-                                                // 32 * 64: sufficient multiple of 32 bytes
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -90,11 +86,11 @@ pub mod pallet {
     ) -> Result<(), Error<T>> {
         log::trace!("Checking size");
         ensure!(
-            (proof).len() <= T::MaxProofSize::get().try_into().unwrap(),
+            (proof).len() <= T::MaxProofSize::get() as usize,
             Error::<T>::InvalidProofSize
         );
         ensure!(
-            (pubs).len() <= T::MaxPubsSize::get().try_into().unwrap(),
+            (pubs).len() <= T::MaxPubsSize::get() as usize,
             Error::<T>::InvalidPublicInputsSize
         );
 

--- a/pallets/settlement-risc0/src/mock.rs
+++ b/pallets/settlement-risc0/src/mock.rs
@@ -17,6 +17,8 @@ use frame_support::{derive_impl, weights::Weight};
 use frame_system;
 use sp_core::ConstU32;
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
+pub const MAX_PROOF_SIZE: u32 = 1000000; // arbitrary length for tests
+pub const MAX_PUBS_SIZE: u32 = 100; // arbitrary length for tests
 
 pub mod on_proof_verified {
     pub use pallet::*;
@@ -84,8 +86,8 @@ impl frame_system::Config for Test {
 impl crate::Config for Test {
     type OnProofVerified = OnProofVerifiedMock;
     type WeightInfo = MockWeightInfo;
-    type MaxProofSize = ConstU32<{ crate::MAX_PROOF_SIZE }>;
-    type MaxPubsSize = ConstU32<{ crate::MAX_PUBS_SIZE }>;
+    type MaxProofSize = ConstU32<MAX_PROOF_SIZE>;
+    type MaxPubsSize = ConstU32<MAX_PUBS_SIZE>;
 }
 
 impl on_proof_verified::pallet::Config for Test {

--- a/pallets/settlement-risc0/src/mock.rs
+++ b/pallets/settlement-risc0/src/mock.rs
@@ -15,6 +15,7 @@
 
 use frame_support::{derive_impl, weights::Weight};
 use frame_system;
+use sp_core::ConstU32;
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
 
 pub mod on_proof_verified {
@@ -83,6 +84,8 @@ impl frame_system::Config for Test {
 impl crate::Config for Test {
     type OnProofVerified = OnProofVerifiedMock;
     type WeightInfo = MockWeightInfo;
+    type MaxProofSize = ConstU32<{ crate::MAX_PROOF_SIZE }>;
+    type MaxPubsSize = ConstU32<{ crate::MAX_PUBS_SIZE }>;
 }
 
 impl on_proof_verified::pallet::Config for Test {

--- a/pallets/settlement-risc0/src/tests.rs
+++ b/pallets/settlement-risc0/src/tests.rs
@@ -21,7 +21,6 @@ use sp_core::H256;
 
 use crate::mock::*;
 use crate::{mock, Error};
-use crate::{MAX_PROOF_SIZE, MAX_PUBS_SIZE};
 
 include!("data.rs");
 pub static VALID_HASH: [u8; 32] =
@@ -112,8 +111,8 @@ fn extend_data(data: &mut Vec<u8>, size: usize) {
 }
 
 #[rstest]
-#[case::too_big_proof(<u32 as TryInto<usize>>::try_into(MAX_PROOF_SIZE).unwrap() - VALID_PROOF.len() + 1, 0, Error::<Test>::InvalidProofSize)]
-#[case::too_big_pubs(0, <u32 as TryInto<usize>>::try_into(MAX_PUBS_SIZE).unwrap() - VALID_PUBS.len() + 1, Error::<Test>::InvalidPublicInputsSize)]
+#[case::too_big_proof((MAX_PROOF_SIZE as usize) - VALID_PROOF.len() + 1, 0, Error::<Test>::InvalidProofSize)]
+#[case::too_big_pubs(0, (MAX_PUBS_SIZE as usize) - VALID_PUBS.len() + 1, Error::<Test>::InvalidPublicInputsSize)]
 fn excessive_size_data_fails_verification_and_is_not_notified(
     #[case] extend_proof: usize,
     #[case] extend_pubs: usize,

--- a/pallets/settlement-risc0/src/tests.rs
+++ b/pallets/settlement-risc0/src/tests.rs
@@ -112,8 +112,8 @@ fn extend_data(data: &mut Vec<u8>, size: usize) {
 }
 
 #[rstest]
-#[case::too_big_proof(MAX_PROOF_SIZE - VALID_PROOF.len() + 1, 0, Error::<Test>::InvalidProofSize)]
-#[case::too_big_pubs(0, MAX_PUBS_SIZE - VALID_PUBS.len() + 1, Error::<Test>::InvalidPublicInputsSize)]
+#[case::too_big_proof(<u32 as TryInto<usize>>::try_into(MAX_PROOF_SIZE).unwrap() - VALID_PROOF.len() + 1, 0, Error::<Test>::InvalidProofSize)]
+#[case::too_big_pubs(0, <u32 as TryInto<usize>>::try_into(MAX_PUBS_SIZE).unwrap() - VALID_PUBS.len() + 1, Error::<Test>::InvalidPublicInputsSize)]
 fn excessive_size_data_fails_verification_and_is_not_notified(
     #[case] extend_proof: usize,
     #[case] extend_pubs: usize,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -343,6 +343,8 @@ impl pallet_settlement_zksync::Config for Runtime {
 impl pallet_settlement_risc0::Config for Runtime {
     type OnProofVerified = Poe;
     type WeightInfo = weights::pallet_settlement_risc0::NHWeight<Runtime>;
+    type MaxProofSize = ConstU32<{ pallet_settlement_risc0::MAX_PROOF_SIZE }>;
+    type MaxPubsSize = ConstU32<{ pallet_settlement_risc0::MAX_PUBS_SIZE }>;
 }
 
 pub const GROTH16_MAX_NUM_INPUTS: u32 = 16;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -340,11 +340,17 @@ impl pallet_settlement_zksync::Config for Runtime {
     type WeightInfo = weights::pallet_settlement_zksync::NHWeight<Runtime>;
 }
 
+parameter_types! {
+    pub const Risc0MaxProofSize: u32 = 1000000; // arbitrary length
+    pub const Risc0MaxPubsSize: u32 = 8 + 4 + 32 * 64; // 8: for bincode::serialize,
+                                                       // 4: bytes for payload length,
+                                                       // 32 * 64: sufficient multiple of 32 bytes
+}
 impl pallet_settlement_risc0::Config for Runtime {
     type OnProofVerified = Poe;
     type WeightInfo = weights::pallet_settlement_risc0::NHWeight<Runtime>;
-    type MaxProofSize = ConstU32<{ pallet_settlement_risc0::MAX_PROOF_SIZE }>;
-    type MaxPubsSize = ConstU32<{ pallet_settlement_risc0::MAX_PUBS_SIZE }>;
+    type MaxProofSize = Risc0MaxProofSize;
+    type MaxPubsSize = Risc0MaxPubsSize;
 }
 
 pub const GROTH16_MAX_NUM_INPUTS: u32 = 16;


### PR DESCRIPTION
The actual values for `MAX_PROOF_SIZE` and `MAX_PUBS_SIZE` are defined at pallet level because they need to be used in:

- `runtime/src/lib.rs`
- `pallets/settlement-risc0/src/mock.rs`
- `pallets/settlement-risc0/src/tests.rs`

otherwise some code duplication would have been introduced.

They are defined as `u32` (instead of `usize`) because Substrate seems to lack `ConstUsize` macro.