### PR TITLE
Fix the docker image version used for coverage

### DIFF
--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base
-  IMAGE_TAG: noble_rust-stable_latest
+  IMAGE_TAG: noble_rust-stable_20240611
   DOCKER_COMPOSE_CMD: "docker compose -f ${GITHUB_WORKSPACE}/ci/docker-compose.yml run --rm cargo-container"
   DOCKER_BUILD_DIR: /build
   DOCKER_CARGO_HOME: /tmp/.cargo


### PR DESCRIPTION
Unfortunally the code coverage on rust 1.79.00 is buggy.

I opened a ticket on rust-lang one moth ago https://github.com/rust-lang/rust/issues/125353 but It was lacking on reproducibility step.

The rust-lang ticket is stalling but I've updated it with the link to the repo to reproduce it and with the information that's landad in stable.

So to make our code coverege CI wokr again we should fix the docker image to the one with rust 1.78.0: `noble_rust-stable_20240611`