### PR TITLE
Gp/ci fixes

### DIFF
--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -46,13 +46,13 @@ jobs:
 
       - name: Cargo coverage
         run: |
-          ${{ env.DOCKER_COMPOSE_CMD }} sh -c '
-            cargo llvm-cov clean --workspace \
+          ${{ env.DOCKER_COMPOSE_CMD }} /bin/bash -c '
+            set -o pipefail \
+            && cargo llvm-cov clean --workspace \
             && find . -name "*.profraw" -delete \
             && cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info \
             && cargo llvm-cov report --json --output-path coverage_report.json --summary-only \
-            && cargo llvm-cov report > coverage_summary.txt \
-            && cat coverage_summary.txt \
+            && cargo llvm-cov report | tee coverage_summary.txt
           '
 
       - name: Upload output(s)

--- a/.github/workflows/CI-e2e-test.yml
+++ b/.github/workflows/CI-e2e-test.yml
@@ -47,8 +47,9 @@ jobs:
         env:
           NODEJS_VERSION_INSTALL: 18
         run: |
-          ${{ env.DOCKER_COMPOSE_CMD }} sh -c '
-            cd ${{ env.DOCKER_BUILD_DIR }}/e2e-tests \
+          ${{ env.DOCKER_COMPOSE_CMD }} /bin/bash -c '
+            set -o pipefail \
+            && cd ${{ env.DOCKER_BUILD_DIR }}/e2e-tests \
             && yarn install \
             && yarn test 2>&1 | tee ${{ env.DOCKER_BUILD_DIR }}/e2e_test_output.txt
           '

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -104,33 +104,33 @@ jobs:
           if [[ "${{ needs.build-test-job.result }}" == "success" ]]; then
             echo "BUILD_TEST_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
           else
-            echo "BUILD_TEST_JOB_EMOJI=:large_red_circle:" >> $GITHUB_ENV
+            echo "BUILD_TEST_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
           fi
 
           if [[ -z "${LINE_COVERAGE_PERCENT}" ]]; then
             if [[ "${{ needs.test-coverage-job.result }}" == "success" ]]; then
               echo "TEST_COVERAGE_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
             else
-              echo "TEST_COVERAGE_JOB_EMOJI=:large_red_circle:" >> $GITHUB_ENV
+              echo "TEST_COVERAGE_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
             fi
           elif [[ "${{ needs.test-coverage-job.result }}" == "success" ]] && (( $(echo "$LINE_COVERAGE_PERCENT >= 70" | bc -l) )); then
             echo "TEST_COVERAGE_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
           elif [[ "${{ needs.test-coverage-job.result }}" == "success" ]]; then
             echo "TEST_COVERAGE_JOB_EMOJI=:large_yellow_circle:" >> $GITHUB_ENV
           else
-            echo "TEST_COVERAGE_JOB_EMOJI=:large_red_circle:" >> $GITHUB_ENV
+            echo "TEST_COVERAGE_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
           fi
 
           if [[ "${{ needs.lint-format-job.result }}" == "success" ]]; then
             echo "LINT_FORMAT_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
           else
-            echo "LINT_FORMAT_JOB_EMOJI=:large_red_circle:" >> $GITHUB_ENV
+            echo "LINT_FORMAT_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
           fi
 
           if [[ "${{ needs.e2e-test-job.result }}" == "success" ]]; then
             echo "E2E_TEST_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
           else
-            echo "E2E_TEST_JOB_EMOJI=:large_red_circle:" >> $GITHUB_ENV
+            echo "E2E_TEST_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
           fi
           echo "OVERALL_STATUS=$OVERALL_STATUS" >> $GITHUB_ENV
       - name: Send Slack Notification
@@ -143,7 +143,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.OVERALL_STATUS_EMOJI }} *NH-CORE BUILD STATUS:* ${{ env.OVERALL_STATUS }} ${{ env.OVERALL_STATUS_EMOJI }}\n*Pull Request:* ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": "${{ env.OVERALL_STATUS_EMOJI }} *ZKVERIFY BUILD STATUS:* ${{ env.OVERALL_STATUS }} ${{ env.OVERALL_STATUS_EMOJI }}\n*Pull Request:* ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
                   }
                 },
                 {


### PR DESCRIPTION
Fixes:

- in `CI-e2e-test.yml` errors generated by command `yarn test` got silenced by subsequent `| tee`; now `/bin/bash` is used with option `set -o pipefail`,
- `:large_red_circle:` was not rendered properly in Slack GUI, so replaced with `:red_circle:`; also `NH-CORE` renamed to `ZKVERIFY`.