### PR TITLE
We cannot use the maximum crate value in benchmarks because the runtime is configured just for 16 and den't accept more.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,6 +5261,8 @@ dependencies = [
  "rstest_reuse",
  "scale-info",
  "sp-core",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -574,12 +574,12 @@ parameter_types! {
 }
 
 impl pallet_groth16_verifier::Config for Runtime {
-    type MaxNumInputs = Groth16MaxNumInputs;
+    const MAX_NUM_INPUTS: u32 = Groth16MaxNumInputs::get();
 }
 
 // We should be sure that the max number of inputs does not exceed the max number of inputs in the verifier crate.
 const_assert!(
-    <Runtime as pallet_groth16_verifier::Config>::MaxNumInputs::get()
+    <Runtime as pallet_groth16_verifier::Config>::MAX_NUM_INPUTS
         <= pallet_groth16_verifier::MAX_NUM_INPUTS
 );
 

--- a/verifiers/groth16/Cargo.toml
+++ b/verifiers/groth16/Cargo.toml
@@ -34,10 +34,11 @@ scale-info = { workspace = true }
 
 frame-support = { workspace = true }
 sp-std = { workspace = true }
-
 sp-core = { workspace = true }
 frame-system = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
+sp-runtime = { workspace = true, optional = true }
+sp-io = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
@@ -57,6 +58,8 @@ std = [
 default = ["std"]
 runtime-benchmarks = [
     "dep:frame-benchmarking",
+    "dep:sp-io",
+    "dep:sp-runtime",
     "pallet-verifiers/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
 ]

--- a/verifiers/groth16/src/lib.rs
+++ b/verifiers/groth16/src/lib.rs
@@ -29,7 +29,6 @@ use data_structures::Scalar;
 use groth16::{Curve, Groth16Error};
 pub use groth16::{ProofWithCurve as Proof, VerificationKeyWithCurve as Vk};
 use hp_verifiers::Verifier;
-use sp_core::Get;
 use sp_std::vec::Vec;
 
 pub const MAX_NUM_INPUTS: u32 = 32;
@@ -37,11 +36,7 @@ pub use weight::WeightInfo;
 
 pub trait Config: 'static {
     /// Maximum supported number of public inputs.
-    type MaxNumInputs: Get<u32>;
-
-    fn max_num_inputs() -> u32 {
-        Self::MaxNumInputs::get()
-    }
+    const MAX_NUM_INPUTS: u32;
 }
 
 #[pallet_verifiers::verifier]
@@ -64,7 +59,7 @@ impl<T: Config> Verifier for Groth16<T> {
         proof: &Self::Proof,
         pubs: &Self::Pubs,
     ) -> Result<(), hp_verifiers::VerifyError> {
-        if pubs.len() > T::max_num_inputs() as usize {
+        if pubs.len() > T::MAX_NUM_INPUTS as usize {
             return Err(hp_verifiers::VerifyError::InvalidInput);
         }
         if pubs.len() + 1 != vk.gamma_abc_g1.len() {

--- a/verifiers/groth16/src/verifier_should.rs
+++ b/verifiers/groth16/src/verifier_should.rs
@@ -18,11 +18,10 @@
 use super::*;
 use rstest::rstest;
 use rstest_reuse::{apply, template};
-use sp_core::ConstU32;
 
 struct Mock;
 impl Config for Mock {
-    type MaxNumInputs = ConstU32<16>;
+    const MAX_NUM_INPUTS: u32 = 16;
 }
 
 #[template]
@@ -43,7 +42,7 @@ fn validate_correct_vk(curve: Curve) {
 
 #[apply(curves)]
 #[case::no_inputs(0)]
-#[case::max_number_of_inputs(Mock::max_num_inputs() as usize)]
+#[case::max_number_of_inputs(Mock::MAX_NUM_INPUTS as usize)]
 fn validate_proof(curve: Curve, #[case] n: usize) {
     let (proof, vk, inputs) = groth16::Groth16::get_instance(n, None, curve);
     assert!(Groth16::<Mock>::verify_proof(&vk, &proof, &inputs).is_ok());
@@ -106,7 +105,7 @@ mod reject {
     #[apply(curves)]
     fn too_many_inputs(curve: Curve) {
         let (proof, vk, inputs) =
-            groth16::Groth16::get_instance(Mock::max_num_inputs() as usize + 1, Some(0), curve);
+            groth16::Groth16::get_instance(Mock::MAX_NUM_INPUTS as usize + 1, Some(0), curve);
 
         assert_eq!(
             Groth16::<Mock>::verify_proof(&vk, &proof, &inputs),


### PR DESCRIPTION
We cannot use the maximum crate value in benchmarks because the runtime is configured just for 16 and den't accept more.

Also add benchmarking tests that was be able to catch this issue.