### PR TITLE
Gp/ci remove check

### DIFF
--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -47,9 +47,6 @@ jobs:
           echo "USER_ID=$(id -u)" >> $GITHUB_ENV
           echo "GRP_ID=$(id -g)" >> $GITHUB_ENV
 
-      - name: Cargo check
-        run: ${{ env.DOCKER_COMPOSE_CMD }} cargo check --all-features --all-targets
-
       - name: Cargo build
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo build --release
 


### PR DESCRIPTION
This PR is for removing CI steps that can be considered almost useless as of now.

Removing `cargo check` is almost a no-brainer, since:

- it takes approx 16 minutes when cache is not available,
- it takes approx 3 minutes when cache is available,
- it is followed by `cargo build`.

Removing `cargo test --test '*'` (integration tests) is opinionated, since:

- it takes approx 2 minutes when cache is not available,
- it takes approx 1 minute when cache is available,
- it actually executes **NO TESTS**,
- can be kept for when actual integration tests will be introduced.