### PR TITLE
Fix circular dependency that stuck vscode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5563,7 +5563,6 @@ name = "pallet-verifiers-macros"
 version = "0.1.0"
 dependencies = [
  "derive-syn-parse 0.2.0",
- "pallet-verifiers",
  "pretty_assertions",
  "proc-macro-crate 3.1.0",
  "proc-macro2",

--- a/pallets/verifiers/macros/Cargo.toml
+++ b/pallets/verifiers/macros/Cargo.toml
@@ -17,8 +17,7 @@ syn = "2.0.66"
 proc-macro2 = "1.0.85"
 derive-syn-parse = "0.2.0"
 proc-macro-crate = "3.1.0"
-rstest.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-pallet-verifiers = { workspace = true, features = ["std"] }
+rstest.workspace = true

--- a/pallets/verifiers/macros/src/lib.rs
+++ b/pallets/verifiers/macros/src/lib.rs
@@ -17,8 +17,7 @@
 //! a new verifier pallet based on `pallet-verifiers` abstraction.
 //!
 
-use proc_macro_crate::FoundCrate;
-use quote::{format_ident, quote, ToTokens};
+use quote::{quote, ToTokens};
 use syn::{parse_macro_input, parse_quote, Attribute, Ident, Token, Type, Visibility};
 
 #[derive(Clone)]
@@ -125,7 +124,11 @@ fn verifier_render(item: Item) -> proc_macro2::TokenStream {
     }
 }
 
+#[cfg(not(test))]
 fn crate_name() -> syn::Path {
+    use proc_macro_crate::FoundCrate;
+    use quote::format_ident;
+
     match proc_macro_crate::crate_name("pallet-verifiers")
         .expect("pallet-verifiers is present in `Cargo.toml` qed")
     {
@@ -135,6 +138,10 @@ fn crate_name() -> syn::Path {
             parse_quote! { #myself }
         }
     }
+}
+#[cfg(test)]
+fn crate_name() -> syn::Path {
+    parse_quote! { pallet_verifiers }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Including pallet-verifiers from pallet-verifiers-macro  also in dev create a circular dependency that cargo resolve but stuck vscode.

I've removed it and simple do a implementation for test that dosn't need it