### PR TITLE
Fix regression on synch

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -25,8 +25,8 @@ mod zksync;
 pub enum VerifyError {
     InvalidInput,
     InvalidProofData,
-    InvalidVerificationKey,
     VerifyError,
+    InvalidVerificationKey,
 }
 
 impl From<VerifyError> for hp_verifiers::VerifyError {


### PR DESCRIPTION
In order to avoid regressions we cannot change the old `enum` positions otherwise old calls will change