### PR TITLE
Moved the data directory renaming before keys handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "mainchain"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "frame-benchmarking",

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -84,6 +84,18 @@ while IFS='=' read -r -d '' var_name var_value; do
   fi
 done < <(env -0)
 
+if [ -n "${ZKV_CONF_BASE_PATH}" ]; then
+  BASE_CHAINS="${ZKV_CONF_BASE_PATH}/chains"
+
+  for chain in local testnet ; do
+    source_chain_dir="${BASE_CHAINS}/nh_${chain}";
+    dest_chain_dir="${BASE_CHAINS}/zkv_${chain}";
+    [ -d "$source_chain_dir" ] && [ ! -e "$dest_chain_dir" ] && \
+      echo "Move ${source_chain_dir} to ${dest_chain_dir}" && \
+      mv "${source_chain_dir}" "${dest_chain_dir}"
+  done
+fi
+
 # Keys handling
 if [ -f "${ZKV_SECRET_PHRASE_PATH}" ]; then
   injection_args=()
@@ -123,17 +135,6 @@ if [[ (-n "${ZKV_CONF_BASE_PATH:-}") && (-n "${ZKV_CONF_CHAIN:-}") && (-f "${ZKV
   echo "Copying node key file"
   cp "${ZKV_NODE_KEY_FILE}" "${destination}/secret_ed25519"
 fi
-
-BASE_CHAINS="/data/node/chains"
-
-for chain in local testnet ; do
-  source_chain_dir="${BASE_CHAINS}/nh_${chain}";
-  dest_chain_dir="${BASE_CHAINS}/zkv_${chain}";
-
-  [ -d "$source_chain_dir" ] && [ ! -e "$dest_chain_dir" ] && \
-    echo "Move ${source_chain_dir} to ${dest_chain_dir}" && \
-    mv "${source_chain_dir}" "${dest_chain_dir}"
-done
 
 echo "Launching ${ZKV_NODE} with args ${conf_args[*]}"
 exec "${ZKV_NODE}" "${conf_args[@]}"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mainchain"
-version = "0.5.0"
+version = "0.5.1"
 description = "zkVerify Mainchain."
 authors.workspace = true
 homepage = "https://github.com/HorizenLabs/zkVerify"


### PR DESCRIPTION
There are cases in which the keys handling results in `zkv_*` directory creation, hence the renaming would be skipped.
Also a fix for handling properly `ZKV_CONF_BASE_PATH` (instead of hard-coded `/data/node/` is provided.


Example:
Bootnodes come with ZKV_NODE_KEY_FILE evaluated and the actual file present.
This code
```
# Node-key handling
if [[ (-n "${ZKV_CONF_BASE_PATH:-}") && (-n "${ZKV_CONF_CHAIN:-}") && (-f "${ZKV_NODE_KEY_FILE}") ]]; then
...
mkdir -p "${destination}"
  echo "Copying node key file"
  cp "${ZKV_NODE_KEY_FILE}" "${destination}/secret_ed25519"
fi
```
results in the `zkv_*` folder being created before `nh_*` being renamed.
The subsequent check `[ ! -e "$dest_chain_dir" ]` fails and no renaming is performed.
The final symptom is the done resyncing from genesis.