### PR TITLE
Gp/ci optimization

### DIFF
--- a/.github/scripts/clean_ci.sh
+++ b/.github/scripts/clean_ci.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-# This script frees up 28 GB of disk space by deleting unneeded packages and 
+# This script frees up some disk space by deleting unneeded packages and 
 # cached docker images.
 #
 echo "=============================================================================="
@@ -24,14 +24,6 @@ echo "==========================================================================
 
 echo "********************************* START SIZE *********************************"
 df -h
-
-# echo "Removing Android library"
-# sudo rm -rf /usr/local/lib/android
-# echo "Removing .NET runtime"
-# sudo rm -rf /usr/share/dotnet
-# echo "Removing Haskell runtime"
-# sudo rm -rf /opt/ghc
-# sudo rm -rf /usr/local/.ghcup
 
 PACKAGES_TO_REMOVE_COUNT=10
 echo "Listing ${PACKAGES_TO_REMOVE_COUNT} largest packages"

--- a/.github/scripts/clean_ci.sh
+++ b/.github/scripts/clean_ci.sh
@@ -22,32 +22,32 @@ echo "==========================================================================
 echo "Freeing up disk space on CI system"
 echo "=============================================================================="
 
-echo "Listing 100 largest packages"
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
 echo "********************************* START SIZE *********************************"
 df -h
-echo "Removing Android library"
-sudo rm -rf /usr/local/lib/android
-echo "Removing .NET runtime"
-sudo rm -rf /usr/share/dotnet
-echo "Removing Haskell runtime"
-sudo rm -rf /opt/ghc
-sudo rm -rf /usr/local/.ghcup
+
+# echo "Removing Android library"
+# sudo rm -rf /usr/local/lib/android
+# echo "Removing .NET runtime"
+# sudo rm -rf /usr/share/dotnet
+# echo "Removing Haskell runtime"
+# sudo rm -rf /opt/ghc
+# sudo rm -rf /usr/local/.ghcup
+
+PACKAGES_TO_REMOVE_COUNT=10
+echo "Listing ${PACKAGES_TO_REMOVE_COUNT} largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n ${PACKAGES_TO_REMOVE_COUNT}
+PACKAGES_TO_REMOVE_LIST=$(dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n ${PACKAGES_TO_REMOVE_COUNT} | awk '{printf "%s ", $2}')
 echo "Removing large packages"
-sudo apt-get remove -y '^aspnetcore-.*'
-sudo apt-get remove -y '^dotnet-.*' --fix-missing
-sudo apt-get remove -y '^temurin-.*' --fix-missing
-sudo apt-get remove -y 'php.*' --fix-missing
-sudo apt-get remove -y '^mongodb-.*' --fix-missing
-sudo apt-get remove -y '^mysql-.*' --fix-missing
-sudo apt-get remove -y google-cloud-sdk --fix-missing
-sudo apt-get remove -y azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing
+sudo apt-get remove -y ${PACKAGES_TO_REMOVE_LIST} --fix-missing
 sudo apt-get autoremove -y
 sudo apt-get clean
+
 echo "************************* AFTER PACKAGES CLEAN SIZE *************************"
 df -h
+
 echo "Removing docker images"
 docker image prune -a -f
+
 echo "********************************* END  SIZE *********************************"
 df -h
 date

--- a/.github/scripts/summarize_tests.sh
+++ b/.github/scripts/summarize_tests.sh
@@ -115,4 +115,4 @@ fi
 passed_formatted="*Passed*: ${e2e_total_passed}"
 failed_formatted="*Failed*: ${e2e_total_failed}"
 runtime_formatted="*Runtime*: ${e2e_total_runtime}s"
-echo "E2E_TEST_SUMMARY=*E2E Tests*\n${passed_formatted}, ${failed_formatted}, ${runtime_formatted}" >> $GITHUB_ENV
+echo "E2E_TEST_SUMMARY=*E2E Tests |* ${passed_formatted}, ${failed_formatted}, ${runtime_formatted}" >> $GITHUB_ENV

--- a/.github/scripts/summarize_tests.sh
+++ b/.github/scripts/summarize_tests.sh
@@ -2,8 +2,8 @@
 set -eEuo pipefail
 
 # Set output file locations
-unit_test_file="./build-and-test-output/unit_tests_output.txt"
-integration_test_file="./build-and-test-output/integration_tests_output.txt"
+unit_test_file="./test-output/unit_tests_output.txt"
+integration_test_file="./test-output/integration_tests_output.txt"
 coverage_report_file="./coverage-output/coverage_report.json"
 e2e_test_file="./e2e-test-output/e2e_test_output.txt"
 
@@ -92,10 +92,10 @@ if [ -f "${coverage_report_file}" ]; then
     instantiations_percent=$(echo "${coverage_totals}" | jq -r '.instantiations.percent' | awk '{printf "%.2f", $0}')
 
     coverage_summary="*Test Coverage Summary (${lines_percent}%)*\n*Functions:* ${functions_count} (${functions_percent}%), *Lines:* ${lines_count} (${lines_percent}%), *Regions:* ${regions_count} (${regions_percent}%), *Instantiations:* ${instantiations_count} (${instantiations_percent}%)"
-    echo "COVERAGE_TEST_SUMMARY=${coverage_summary}" >> $GITHUB_ENV
+    echo "COVERAGE_SUMMARY=${coverage_summary}" >> $GITHUB_ENV
     echo "LINE_COVERAGE_PERCENT=${lines_percent}" >> $GITHUB_ENV
 else
-    echo "COVERAGE_TEST_SUMMARY=Coverage data not found." >> $GITHUB_ENV
+    echo "COVERAGE_SUMMARY=Coverage data not found." >> $GITHUB_ENV
 fi
 
 # Process e2e test file

--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -4,7 +4,11 @@ run-name: "Workflow CI/CD Steps: build, unit and integration testing"
 
 on:
   workflow_call:
-
+    inputs:
+      CACHING_MODE:
+        required: true
+        type: string
+        
 env:
   IMAGE_NAME: zencash/sc-ci-base
   IMAGE_TAG: noble_rust-stable_latest
@@ -27,20 +31,25 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        continue-on-error: true
+      - name: Restore common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
             deps/
-          key: build-test-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: build-test-cargo-
+          key: common-cache
+    
+      - name: Restore build-test cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            target/
+          key: build-test-cache
 
       - name: Set docker env vars
         run: |
@@ -57,6 +66,26 @@ jobs:
       - name: Cargo integration tests
         shell: bash
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo test --test '*' --all-features --no-fail-fast --release 2>&1 | tee integration_tests_output.txt
+
+      - name: Save common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            deps/
+          key: common-cache
+    
+      - name: Save build-test cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: build-test-cache
 
       - name: Upload output(s)
         if: ${{ !env.ACT }}

--- a/.github/workflows/CI-build-test.yml
+++ b/.github/workflows/CI-build-test.yml
@@ -4,7 +4,6 @@ run-name: "Workflow CI/CD Steps: build, unit and integration testing"
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -1,6 +1,6 @@
-name: End-to-end-test
+name: Build
 
-run-name: "Workflow CI/CD Steps: end-to-end test on zombienet"
+run-name: "Workflow CI/CD Steps: build, unit and integration testing"
 
 on:
   workflow_call:
@@ -8,7 +8,7 @@ on:
       CACHING_MODE:
         required: true
         type: string
-
+        
 env:
   IMAGE_NAME: zencash/sc-ci-base
   IMAGE_TAG: noble_rust-stable_latest
@@ -18,11 +18,15 @@ env:
   CMAKE_INSTALL: true
 
 jobs:
-  e2e-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
+
+      - name: Free up disk space
+        if: ${{ !env.ACT }}
+        run: ${GITHUB_WORKSPACE}/.github/scripts/clean_ci.sh
 
       - name: Set up deps cache
         run: mkdir deps
@@ -39,13 +43,13 @@ jobs:
             deps/
           key: common-cache
     
-      - name: Restore e2e-test cache
+      - name: Restore build cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
         uses: actions/cache/restore@v3
         with:
           path: |
             target/
-          key: build-cache # same cache as "build" job (since "cargo build --release" is used in both jobs)
+          key: build-cache
 
       - name: Set docker env vars
         run: |
@@ -55,25 +59,22 @@ jobs:
       - name: Cargo build
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo build --release
 
-      - name: Yarn install and test
-        shell: bash
-        env:
-          NODEJS_VERSION_INSTALL: 18
-        run: |
-          ${{ env.DOCKER_COMPOSE_CMD }} /bin/bash -c '
-            set -o pipefail \
-            && cd ${{ env.DOCKER_BUILD_DIR }}/e2e-tests \
-            && yarn install \
-            && yarn test 2>&1 | tee ${{ env.DOCKER_BUILD_DIR }}/e2e_test_output.txt
-          '
-          
-      - name: Upload output(s)
-        if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@v4
+      - name: Save common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
         with:
-          name: e2e-test-output
-          path: e2e_test_output.txt
-          if-no-files-found: warn
-          retention-days: 1
-          compression-level: 0
-          overwrite: true
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            deps/
+          key: common-cache
+    
+      - name: Save build cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: build-cache

--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
-      - name: Free up disk space
-        if: ${{ !env.ACT }}
-        run: ${GITHUB_WORKSPACE}/.github/scripts/clean_ci.sh
-
       - name: Set up deps cache
         run: mkdir deps
 

--- a/.github/workflows/CI-cache-manager.yml
+++ b/.github/workflows/CI-cache-manager.yml
@@ -1,0 +1,51 @@
+name: Cache manager
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # Runs every Sunday at 0:00 UTC
+  workflow_dispatch:
+
+jobs:
+
+  clear-caches-job:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Clear caches
+        run: |
+          sudo apt-get install gh
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
+          caches_list=$(gh cache list)
+          if [ -z "${caches_list}" ]; then
+            echo "No caches to delete"
+          else
+            echo ${caches_list}
+            gh cache delete --all
+          fi
+
+  build-test-job:
+    needs: [clear-caches-job]
+    uses: ./.github/workflows/CI-build-test.yml
+    with:
+      CACHING_MODE: "CACHE_SAVE"
+
+  test-coverage-job:
+    needs: [clear-caches-job]
+    uses: ./.github/workflows/CI-coverage.yml
+    with:
+      CACHING_MODE: "CACHE_SAVE"
+
+  lint-format-job:
+    needs: [clear-caches-job]
+    uses: ./.github/workflows/CI-lint-format.yml
+    with:
+      CACHING_MODE: "CACHE_SAVE"
+    
+  e2e-test-job:
+    needs: [clear-caches-job]
+    uses: ./.github/workflows/CI-e2e-test.yml
+    with:
+      CACHING_MODE: "CACHE_SAVE"

--- a/.github/workflows/CI-cache-manager.yml
+++ b/.github/workflows/CI-cache-manager.yml
@@ -26,13 +26,19 @@ jobs:
             gh cache delete --all
           fi
 
-  build-test-job:
+  build-job:
     needs: [clear-caches-job]
-    uses: ./.github/workflows/CI-build-test.yml
+    uses: ./.github/workflows/CI-build.yml
     with:
       CACHING_MODE: "CACHE_SAVE"
 
-  test-coverage-job:
+  test-job:
+    needs: [clear-caches-job]
+    uses: ./.github/workflows/CI-test.yml
+    with:
+      CACHING_MODE: "CACHE_SAVE"
+
+  coverage-job:
     needs: [clear-caches-job]
     uses: ./.github/workflows/CI-coverage.yml
     with:

--- a/.github/workflows/CI-cache-manager.yml
+++ b/.github/workflows/CI-cache-manager.yml
@@ -43,9 +43,3 @@ jobs:
     uses: ./.github/workflows/CI-lint-format.yml
     with:
       CACHING_MODE: "CACHE_SAVE"
-    
-  e2e-test-job:
-    needs: [clear-caches-job]
-    uses: ./.github/workflows/CI-e2e-test.yml
-    with:
-      CACHING_MODE: "CACHE_SAVE"

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        if: ${{ !env.ACT }}
+        run: ${GITHUB_WORKSPACE}/.github/scripts/clean_ci.sh
+
       - name: Set up deps cache
         run: mkdir deps
 

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -4,6 +4,10 @@ run-name: "Workflow CI/CD Steps: coverage"
 
 on:
   workflow_call:
+    inputs:
+      CACHING_MODE:
+        required: true
+        type: string
 
 env:
   IMAGE_NAME: zencash/sc-ci-base
@@ -28,20 +32,25 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        continue-on-error: true
+      - name: Restore common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
             deps/
-          key: coverage-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: coverage-cargo-
+          key: common-cache
+    
+      - name: Restore coverage cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            target/
+          key: coverage-cache
 
       - name: Set docker env vars
         run: |
@@ -58,6 +67,14 @@ jobs:
             && cargo llvm-cov report --json --output-path coverage_report.json --summary-only \
             && cargo llvm-cov report | tee coverage_summary.txt
           '
+
+      - name: Save coverage cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: coverage-cache
 
       - name: Upload output(s)
         if: ${{ !env.ACT }}

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -25,10 +25,6 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
-      - name: Free up disk space
-        if: ${{ !env.ACT }}
-        run: ${GITHUB_WORKSPACE}/.github/scripts/clean_ci.sh
-
       - name: Set up deps cache
         run: mkdir deps
 

--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -4,7 +4,6 @@ run-name: "Workflow CI/CD Steps: coverage"
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base

--- a/.github/workflows/CI-e2e-test.yml
+++ b/.github/workflows/CI-e2e-test.yml
@@ -4,6 +4,10 @@ run-name: "Workflow CI/CD Steps: end-to-end test on zombienet"
 
 on:
   workflow_call:
+    inputs:
+      CACHING_MODE:
+        required: true
+        type: string
 
 env:
   IMAGE_NAME: zencash/sc-ci-base
@@ -23,20 +27,25 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        continue-on-error: true
+      - name: Restore common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
             deps/
-          key: e2e-test-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: e2e-test-cargo-
+          key: common-cache
+    
+      - name: Restore e2e-test cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            target/
+          key: e2e-test-cache
 
       - name: Set docker env vars
         run: |
@@ -58,6 +67,14 @@ jobs:
             && yarn test 2>&1 | tee ${{ env.DOCKER_BUILD_DIR }}/e2e_test_output.txt
           '
 
+      - name: Save e2e-test cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: e2e-test-cache
+          
       - name: Upload output(s)
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI-e2e-test.yml
+++ b/.github/workflows/CI-e2e-test.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           path: |
             target/
-          key: e2e-test-cache
+          key: build-test-cache # same cache as "build-test" job (since "cargo build --release" is used in both jobs)
 
       - name: Set docker env vars
         run: |
@@ -66,14 +66,6 @@ jobs:
             && yarn install \
             && yarn test 2>&1 | tee ${{ env.DOCKER_BUILD_DIR }}/e2e_test_output.txt
           '
-
-      - name: Save e2e-test cache
-        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            target/
-          key: e2e-test-cache
           
       - name: Upload output(s)
         if: ${{ !env.ACT }}

--- a/.github/workflows/CI-e2e-test.yml
+++ b/.github/workflows/CI-e2e-test.yml
@@ -4,7 +4,6 @@ run-name: "Workflow CI/CD Steps: end-to-end test on zombienet"
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base

--- a/.github/workflows/CI-lint-format.yml
+++ b/.github/workflows/CI-lint-format.yml
@@ -4,7 +4,6 @@ run-name: "Workflow CI/CD Steps: lint and format"
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base

--- a/.github/workflows/CI-lint-format.yml
+++ b/.github/workflows/CI-lint-format.yml
@@ -4,6 +4,10 @@ run-name: "Workflow CI/CD Steps: lint and format"
 
 on:
   workflow_call:
+    inputs:
+      CACHING_MODE:
+        required: true
+        type: string
 
 env:
   IMAGE_NAME: zencash/sc-ci-base
@@ -23,20 +27,25 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        continue-on-error: true
+      - name: Restore common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
             deps/
-          key: lint-format-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: lint-format-cargo-
+          key: common-cache
+    
+      - name: Restore lint-format cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            target/
+          key: lint-format-cache
 
       - name: Set docker env vars
         run: |
@@ -50,6 +59,14 @@ jobs:
       - name: Formatting
         shell: bash
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo fmt --check 2>&1 | tee formatting_output.txt
+
+      - name: Save lint-format-test cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            target/
+          key: lint-format-cache
 
       - name: Upload output(s)
         if: ${{ !env.ACT }}

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -6,12 +6,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-test-job:
-    uses: ./.github/workflows/CI-build-test.yml
+  build-job:
+    uses: ./.github/workflows/CI-build.yml
     with:
       CACHING_MODE: "CACHE_RESTORE"
 
-  test-coverage-job:
+  test-job:
+    uses: ./.github/workflows/CI-test.yml
+    with:
+      CACHING_MODE: "CACHE_RESTORE"
+      
+  coverage-job:
     uses: ./.github/workflows/CI-coverage.yml
     with:
       CACHING_MODE: "CACHE_RESTORE"
@@ -42,7 +47,7 @@ jobs:
 
   set-overall-result:
     runs-on: ubuntu-latest
-    needs: [build-test-job, test-coverage-job, lint-format-job, e2e-test-job, check-act]
+    needs: [build-job, test-job, coverage-job, lint-format-job, e2e-test-job, check-act]
     if: ${{ always() && needs.check-act.outputs.act == 'false' }}
     outputs:
       branch-name: ${{ steps.get-info.outputs.BRANCH_NAME }}
@@ -73,8 +78,9 @@ jobs:
             OVERALL_STATUS="cancelled"
           else
             OVERALL_STATUS="success"
-            if [ "${{ needs.build-test-job.result }}" != "success" ] || 
-                [ "${{ needs.test-coverage-job.result }}" != "success" ] ||
+            if [ "${{ needs.build-job.result }}" != "success" ] || 
+                [ "${{ needs.test-job.result }}" != "success" ] ||
+                [ "${{ needs.coverage-job.result }}" != "success" ] ||
                 [ "${{ needs.lint-format-job.result }}" != "success" ] || 
                 [ "${{ needs.e2e-test-job.result }}" != "success" ]; then
               OVERALL_STATUS="failure"
@@ -94,15 +100,16 @@ jobs:
           
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [build-test-job, test-coverage-job, lint-format-job, e2e-test-job, check-act, set-overall-result]
+    needs: [build-job, test-job, coverage-job, lint-format-job, e2e-test-job, check-act, set-overall-result]
     if: ${{ always() && needs.check-act.outputs.act == 'false' && needs.set-overall-result.outputs.overall-status != 'cancelled' }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
       - name: Report Job Statuses
         run: |
-          echo "Build and Test Job Status: ${{ needs.build-test-job.result }}"
-          echo "Test Coverage Job Status: ${{ needs.test-coverage-job.result }}"
+          echo "Build Job Status: ${{ needs.build-job.result }}"
+          echo "Test Job Status: ${{ needs.test-job.result }}"
+          echo "Coverage Job Status: ${{ needs.coverage-job.result }}"
           echo "Lint and Format Job Status: ${{ needs.lint-format-job.result }}"
           echo "E2E Test Job Status: ${{ needs.e2e-test-job.result }}"
       - name: Download All Artifacts
@@ -113,15 +120,15 @@ jobs:
         run: ./.github/scripts/summarize_tests.sh
       - name: Display unit test output
         run: |
-          if [ -f "./build-and-test-output/unit_tests_output.txt" ]; then
-            cat "./build-and-test-output/unit_tests_output.txt"
+          if [ -f "./test-output/unit_tests_output.txt" ]; then
+            cat "./test-output/unit_tests_output.txt"
           else
             echo "Unit test output not found."
           fi
       - name: Display integration test output
         run: |
-          if [ -f "./build-and-test-output/integration_tests_output.txt" ]; then
-            cat "./build-and-test-output/integration_tests_output.txt"
+          if [ -f "./test-output/integration_tests_output.txt" ]; then
+            cat "./test-output/integration_tests_output.txt"
           else
             echo "Integration test output not found."
           fi
@@ -130,7 +137,7 @@ jobs:
           if [ -f "./coverage-output/coverage_report.json" ]; then
             cat "./coverage-output/coverage_report.json"
           else
-            echo "Test Coverage output not found."
+            echo "Coverage output not found."
           fi
       - name: Display linting output
         run: |
@@ -179,24 +186,30 @@ jobs:
             echo "OVERALL_STATUS_EMOJI=:alert:" >> $GITHUB_ENV
           fi
       
-          if [[ "${{ needs.build-test-job.result }}" == "success" ]]; then
-            echo "BUILD_TEST_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
+          if [[ "${{ needs.build-job.result }}" == "success" ]]; then
+            echo "BUILD_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
           else
-            echo "BUILD_TEST_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
+            echo "BUILD_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
+          fi
+
+          if [[ "${{ needs.test-job.result }}" == "success" ]]; then
+            echo "TEST_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
+          else
+            echo "TEST_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
           fi
       
           if [[ -z "${LINE_COVERAGE_PERCENT}" ]]; then
-            if [[ "${{ needs.test-coverage-job.result }}" == "success" ]]; then
-              echo "TEST_COVERAGE_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
+            if [[ "${{ needs.coverage-job.result }}" == "success" ]]; then
+              echo "COVERAGE_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
             else
-              echo "TEST_COVERAGE_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
+              echo "COVERAGE_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
             fi
-          elif [[ "${{ needs.test-coverage-job.result }}" == "success" ]] && (( $(echo "$LINE_COVERAGE_PERCENT >= 70" | bc -l) )); then
-            echo "TEST_COVERAGE_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
-          elif [[ "${{ needs.test-coverage-job.result }}" == "success" ]]; then
-            echo "TEST_COVERAGE_JOB_EMOJI=:large_yellow_circle:" >> $GITHUB_ENV
+          elif [[ "${{ needs.coverage-job.result }}" == "success" ]] && (( $(echo "$LINE_COVERAGE_PERCENT >= 70" | bc -l) )); then
+            echo "COVERAGE_JOB_EMOJI=:large_green_circle:" >> $GITHUB_ENV
+          elif [[ "${{ needs.coverage-job.result }}" == "success" ]]; then
+            echo "COVERAGE_JOB_EMOJI=:large_yellow_circle:" >> $GITHUB_ENV
           else
-            echo "TEST_COVERAGE_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
+            echo "COVERAGE_JOB_EMOJI=:red_circle:" >> $GITHUB_ENV
           fi
       
           if [[ "${{ needs.lint-format-job.result }}" == "success" ]]; then
@@ -227,21 +240,28 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.BUILD_TEST_JOB_EMOJI }} *Build & Test:* ${{ needs.build-test-job.result }}\n\n${{ env.UNIT_TEST_SUMMARY }}\n${{ env.INTEGRATION_TEST_SUMMARY }}"
+                    "text": "${{ env.BUILD_JOB_EMOJI }} *Build & Test:* ${{ needs.build-job.result }}"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.TEST_COVERAGE_JOB_EMOJI }} *Test Coverage:* ${{ needs.test-coverage-job.result }}\n\n${{ env.COVERAGE_TEST_SUMMARY }}"
+                    "text": "${{ env.TEST_JOB_EMOJI }} *Build & Test:* ${{ needs.test-job.result }}\n\n${{ env.UNIT_TEST_SUMMARY }}\n${{ env.INTEGRATION_TEST_SUMMARY }}"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.LINT_FORMAT_JOB_EMOJI }} *Lint & Format:*  ${{ needs.lint-format-job.result }}"
+                    "text": "${{ env.COVERAGE_JOB_EMOJI }} *Coverage:* ${{ needs.coverage-job.result }}\n\n${{ env.COVERAGE_SUMMARY }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.LINT_FORMAT_JOB_EMOJI }} *Lint & Format:* ${{ needs.lint-format-job.result }}"
                   }
                 },
                 {

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -86,14 +86,18 @@ jobs:
               OVERALL_STATUS="failure"
             fi
   
-            echo Setting overall result
-            curl -L --fail \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${LAST_COMMIT_SHA}" \
-            -d '{"state":"'${OVERALL_STATUS}'","context":"Orchestrator"}'
+            if [ ${LAST_COMMIT_SHA} != "" ]; then
+              echo Setting overall result
+              curl -L --fail \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${LAST_COMMIT_SHA}" \
+              -d '{"state":"'${OVERALL_STATUS}'","context":"Orchestrator"}'
+            else
+              echo Unable to set overall result
+            fi
           fi
   
           echo "OVERALL_STATUS=$OVERALL_STATUS" >> $GITHUB_OUTPUT
@@ -240,14 +244,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.BUILD_JOB_EMOJI }} *Build & Test:* ${{ needs.build-job.result }}"
+                    "text": "${{ env.BUILD_JOB_EMOJI }} *Build:* ${{ needs.build-job.result }}"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.TEST_JOB_EMOJI }} *Build & Test:* ${{ needs.test-job.result }}\n\n${{ env.UNIT_TEST_SUMMARY }}\n${{ env.INTEGRATION_TEST_SUMMARY }}"
+                    "text": "${{ env.TEST_JOB_EMOJI }} *Test:* ${{ needs.test-job.result }}\n\n${{ env.UNIT_TEST_SUMMARY }}\n${{ env.INTEGRATION_TEST_SUMMARY }}"
                   }
                 },
                 {

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -8,10 +8,13 @@ on:
 jobs:
   build-test-job:
     uses: ./.github/workflows/CI-build-test.yml
+
   test-coverage-job:
     uses: ./.github/workflows/CI-coverage.yml
+
   lint-format-job:
     uses: ./.github/workflows/CI-lint-format.yml
+    
   e2e-test-job:
     uses: ./.github/workflows/CI-e2e-test.yml
 

--- a/.github/workflows/CI-orchestrator.yml
+++ b/.github/workflows/CI-orchestrator.yml
@@ -8,15 +8,23 @@ on:
 jobs:
   build-test-job:
     uses: ./.github/workflows/CI-build-test.yml
+    with:
+      CACHING_MODE: "CACHE_RESTORE"
 
   test-coverage-job:
     uses: ./.github/workflows/CI-coverage.yml
+    with:
+      CACHING_MODE: "CACHE_RESTORE"
 
   lint-format-job:
     uses: ./.github/workflows/CI-lint-format.yml
-    
+    with:
+      CACHING_MODE: "CACHE_RESTORE"
+
   e2e-test-job:
     uses: ./.github/workflows/CI-e2e-test.yml
+    with:
+      CACHING_MODE: "CACHE_RESTORE"
 
   check-act:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI-rustdoc.yml
+++ b/.github/workflows/CI-rustdoc.yml
@@ -4,6 +4,10 @@ run-name: "Workflow CI/CD Steps: rust doc generation"
 
 on:
   workflow_call:
+    inputs:
+      CACHING_MODE:
+        required: true
+        type: string
 
 env:
   IMAGE_NAME: zencash/sc-ci-base
@@ -23,26 +27,18 @@ jobs:
       - name: Set up deps cache
         run: mkdir deps
 
-      - name: Set up cargo cache
-        uses: actions/cache@v4
-        if: ${{ !env.ACT }}
-        continue-on-error: true
+      - name: Restore common cache
+        if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
             deps/
-          key: rustdoc-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: rustdoc-cargo-
-
-      - name: Set docker env vars
-        run: |
-          echo "USER_ID=$(id -u)" >> $GITHUB_ENV
-          echo "GRP_ID=$(id -g)" >> $GITHUB_ENV
-
+          key: common-cache
+    
       - name: Generate Rust documentation
         run: ${{ env.DOCKER_COMPOSE_CMD }} cargo doc --no-deps --release
 

--- a/.github/workflows/CI-rustdoc.yml
+++ b/.github/workflows/CI-rustdoc.yml
@@ -4,7 +4,6 @@ run-name: "Workflow CI/CD Steps: rust doc generation"
 
 on:
   workflow_call:
-  workflow_dispatch:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base

--- a/.github/workflows/CI-tag-orchestrator.yml
+++ b/.github/workflows/CI-tag-orchestrator.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           source "${GITHUB_WORKSPACE}/ci/setup_env.sh"
           "${GITHUB_WORKSPACE}/ci/docker.sh"
+
   rustdoc-job:
-    needs: docker-job
     uses: ./.github/workflows/CI-rustdoc.yml
 
   notify-slack:

--- a/.github/workflows/CI-tag-orchestrator.yml
+++ b/.github/workflows/CI-tag-orchestrator.yml
@@ -31,6 +31,8 @@ jobs:
 
   rustdoc-job:
     uses: ./.github/workflows/CI-rustdoc.yml
+    with:
+      CACHING_MODE: "CACHE_RESTORE"
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -1,4 +1,4 @@
-name: Build-and-Test
+name: Test
 
 run-name: "Workflow CI/CD Steps: build, unit and integration testing"
 
@@ -18,7 +18,7 @@ env:
   CMAKE_INSTALL: true
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
@@ -43,21 +43,18 @@ jobs:
             deps/
           key: common-cache
     
-      - name: Restore build-test cache
+      - name: Restore test cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_RESTORE' }}
         uses: actions/cache/restore@v3
         with:
           path: |
             target/
-          key: build-test-cache
+          key: test-cache
 
       - name: Set docker env vars
         run: |
           echo "USER_ID=$(id -u)" >> $GITHUB_ENV
           echo "GRP_ID=$(id -g)" >> $GITHUB_ENV
-
-      - name: Cargo build
-        run: ${{ env.DOCKER_COMPOSE_CMD }} cargo build --release
 
       - name: Cargo unit tests
         shell: bash
@@ -79,19 +76,19 @@ jobs:
             deps/
           key: common-cache
     
-      - name: Save build-test cache
+      - name: Save test cache
         if: ${{ !env.ACT && inputs.CACHING_MODE == 'CACHE_SAVE' }}
         uses: actions/cache/save@v3
         with:
           path: |
             target/
-          key: build-test-cache
+          key: test-cache
 
       - name: Upload output(s)
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
-          name: build-and-test-output
+          name: test-output
           path: |
             unit_tests_output.txt
             integration_tests_output.txt

--- a/.github/workflows/CI-test.yml
+++ b/.github/workflows/CI-test.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v4
 
-      - name: Free up disk space
-        if: ${{ !env.ACT }}
-        run: ${GITHUB_WORKSPACE}/.github/scripts/clean_ci.sh
-
       - name: Set up deps cache
         run: mkdir deps
 

--- a/ci/profile-CI.py
+++ b/ci/profile-CI.py
@@ -21,7 +21,7 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 STOP_AFTER_PROCESSED_DEFAULT = 10
 SKIP_DEFAULT = 0
-JOBS_TO_PROFILE_DEFAULT = ['build-test-job / build-and-test', 'test-coverage-job / coverage', 'lint-format-job / lint-and-format', 'e2e-test-job / e2e-test']
+JOBS_TO_PROFILE_DEFAULT = ['build-job / build', 'test-job / test', 'coverage-job / coverage', 'lint-format-job / lint-and-format', 'e2e-test-job / e2e-test']
 
 def parse_arguments():
     """

--- a/ci/profile-CI.py
+++ b/ci/profile-CI.py
@@ -1,0 +1,81 @@
+"""
+A script to automatically profile CI runs.
+Runs are queried from most recent to least recent and processed only if successfully completed.
+
+Usage examples:
+    python3 ci/profile-CI.py --help
+    python3 ci/profile-CI.py ghp_0123456789ABCDEF0123456789ABCDEF0123
+    python3 ci/profile-CI.py ghp_0123456789ABCDEF0123456789ABCDEF0123 --stop-after-processed 5
+
+NOTE: if you incur in `403 - rate limit exceeded` error, wait some time for refreshment and use parameters
+      `--stop-after-processed` and `--skip` to query the runs you need.
+"""
+
+import requests
+import argparse
+from datetime import datetime
+
+REPOSITORY_OWNER = 'HorizenLabs'
+REPOSITORY = 'zkVerify'
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+STOP_AFTER_PROCESSED_DEFAULT = 10
+SKIP_DEFAULT = 0
+JOBS_TO_PROFILE_DEFAULT = ['build-test-job / build-and-test', 'test-coverage-job / coverage', 'lint-format-job / lint-and-format', 'e2e-test-job / e2e-test']
+
+def parse_arguments():
+    """
+    Parse command-line arguments and return the parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description="Profile CI runs")
+    parser.add_argument("token", help="GitHub personal access token (for avoiding rate limit threshold)")
+    parser.add_argument("--stop-after-processed", nargs='?', type=int, default=STOP_AFTER_PROCESSED_DEFAULT, help="stop after processing N successfully completed workflow runs")
+    parser.add_argument("--skip", nargs='?', type=int, default=SKIP_DEFAULT, help="skip first N successfully completed workflow runs")
+    parser.add_argument("--jobs-to-profile", nargs='*', default=JOBS_TO_PROFILE_DEFAULT, help="names of the jobs to profile")
+    return parser.parse_args()
+
+
+# MAIN
+if __name__ == "__main__":
+    # Parse command-line arguments
+    args = parse_arguments()
+
+    headers = {
+        'Authorization': '{Bearer ' + args.token + '}',
+        'Accept': 'application/vnd.github+json'
+    }
+    url_runs = f'https://api.github.com/repos/{REPOSITORY_OWNER}/{REPOSITORY}/actions/runs'
+    response = requests.get(url_runs, headers=headers)
+    if response.status_code == 200:
+        print(f"Run_Id;Run_Number;Job_Id;Total_Seconds")
+        processed = 0
+        skipped = 0
+        workflow_runs = response.json()
+        for run in workflow_runs['workflow_runs']:
+            if processed == args.stop_after_processed:
+                break
+            if run['status'] == 'completed' and run['conclusion'] == 'success':
+                if skipped < args.skip:
+                    skipped = skipped + 1
+                    continue
+                processed = processed + 1
+                url_run_single = f'https://api.github.com/repos/{REPOSITORY_OWNER}/{REPOSITORY}/actions/runs/{run["id"]}/timing'
+                response = requests.get(url_run_single, headers=headers)
+                if response.status_code == 200:
+                    workflow_run_details = response.json()
+                    for job in workflow_run_details['billable']['UBUNTU']['job_runs']:
+                        url_job_single = f'https://api.github.com/repos/{REPOSITORY_OWNER}/{REPOSITORY}/actions/jobs/{job["job_id"]}'
+                        response = requests.get(url_job_single, headers=headers)
+                        if response.status_code == 200:
+                            job_run_single = response.json()
+                            if (job_run_single['name'] in args.jobs_to_profile):
+                                datetime_started = datetime.strptime(job_run_single['started_at'], DATE_FORMAT)
+                                datetime_completed = datetime.strptime(job_run_single['completed_at'], DATE_FORMAT)
+                                datetime_diff = datetime_completed - datetime_started
+                                print(f"{run['id']};{run['run_number']};{job_run_single['name']};{datetime_diff.total_seconds()}")
+                        else:
+                            print(f"Failed to get job run details: {response.status_code} - {response.reason}")
+                else:
+                    print(f"Failed to get workflow run details: {response.status_code} - {response.reason}")
+    else:
+        print(f"Failed to get workflow runs: {response.status_code} - {response.reason}")

--- a/ci/run_locally.sh
+++ b/ci/run_locally.sh
@@ -51,7 +51,7 @@ fi
 ####
 # Running workflow(s)
 ####
-workflows_orchestrator="CI-build-test CI-coverage CI-lint-format CI-e2e-test"
+workflows_orchestrator="CI-build CI-test CI-coverage CI-lint-format CI-e2e-test"
 workflows_extra="CI-rustdoc"
 if [ "${interactive_mode}" == 'true' ];then
   workflows="${workflows_orchestrator} ${workflows_extra}"


### PR DESCRIPTION
This PR introduces the following improvements for the CI (sorted by commit history):

- introduction of a Python script (`profile-CI.py`) for automatic profiling of CI runs,
- refactoring of script (`clean_ci.sh`) for cleaning GitHubActions runner; now the N largest packages are removed (instead of an hard-coded list),
- `docker-job` and Crustdoc-job` now run in parallel, since they are independent,
- removal of on-demand run trigger for workflows that should be triggered only by other workflows,
- changes to caches management; now:
  - each Sunday at 0:00 UTC a workflow (`Cache manager`) runs on `main` branch; it deletes all caches and executes the build, test, coverage and lint-format jobs saving the corresponding caches (write-only),
  - every run of `Orchestrator` and `Tag-orchestrator` runs restoring the available caches (read-only),
  - in this way the frequent runs of `Orchestrator` always have a recent cache available (7 days old at worst),
- refactoring for `End-to-end-test` job, now using `build-cache`,
- refactoring for `Build-and-Test` job (now split in `Build` job and `Test` job),
- other minor fixes.

Currently the profiling of 12 recent runs (244, 245, 246, 249, 250, 251, 252, 253, 256, 257, 259, 260) is reported in this table:

| Job | Average execution time (s) |
| - | - |
| **`build-test-job / build-and-test`** | **2423.75** |
| `e2e-test-job / e2e-test` | 2137.75 |
| `lint-format-job / lint-and-format` | 1489 |
| `test-coverage-job / coverage` | 2357.75 |

the `build-test-job / build-and-test` being the bottleneck.

The plan is to analyse again the situation on some future CI runs after this PR is merged.