### PR TITLE
Use polkadot crypto from zombie

### DIFF
--- a/e2e-tests/js_scripts/0008-update-runtime-multisig-scheduler.js
+++ b/e2e-tests/js_scripts/0008-update-runtime-multisig-scheduler.js
@@ -1,4 +1,4 @@
-const util = require('@polkadot/util-crypto');
+const util = zombie.util;
 const { submitExtrinsic, BlockUntil } = require('zkv-lib')
 const ReturnCode = {
     Ok: 1,
@@ -9,11 +9,11 @@ const ReturnCode = {
 const fs = require('fs');
 
 async function run(nodeName, networkInfo, args) {
-    const {wsUri, userDefinedTypes} = networkInfo.nodesByName[nodeName];
+    const { wsUri, userDefinedTypes } = networkInfo.nodesByName[nodeName];
     const api = await zombie.connect(wsUri, userDefinedTypes);
 
     const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
-    const BOB   = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+    const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
     const CHARLIE = '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y';
 
     // Use the keyring to generate accounts
@@ -118,7 +118,7 @@ async function run(nodeName, networkInfo, args) {
 
     const updatedRuntimeVersion = (await api.rpc.state.getRuntimeVersion()).specVersion.toNumber();
 
-    if(updatedRuntimeVersion === currentRuntimeVersion) {
+    if (updatedRuntimeVersion === currentRuntimeVersion) {
         return ReturnCode.ErrSameRuntimeVersion
     }
 


### PR DESCRIPTION
We should not import @polkadot/util-crypto again because is already exported in zombie

https://github.com/paritytech/zombienet/blob/e9f0993f15ed4a8d9ad1589056ea188ed1b0d039/javascript/packages/orchestrator/src/test-runner/assertions.ts#L303C13-L303C23