### PR TITLE
Disable verifier feature

### DIFF
--- a/pallets/verifiers/Cargo.toml
+++ b/pallets/verifiers/Cargo.toml
@@ -48,6 +48,7 @@ std = [
     "hp-verifiers/std",
     "hp-poe/std",
 ]
+
 try-runtime = ["frame-support/try-runtime", "frame-system/try-runtime"]
 runtime-benchmarks = [
     "frame-benchmarking/runtime-benchmarks",

--- a/pallets/verifiers/src/common.rs
+++ b/pallets/verifiers/src/common.rs
@@ -1,0 +1,42 @@
+//! The common pallet-verifiers component.
+
+pub use pallet::*;
+
+use frame_support::weights::Weight;
+use sp_core::Get;
+
+/// Weight functions needed for `pallet_poe`.
+#[allow(missing_docs)]
+pub trait WeightInfo {
+    fn disable_verifier() -> Weight;
+    fn on_verify_disabled_verifier() -> Weight;
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::WeightInfo;
+
+    #[pallet::pallet]
+    /// The common pallet-verifiers component.
+    pub struct Pallet<T>(_);
+
+    /// Configure the pallet by specifying the parameters and types on which it depends.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// Weights
+        type CommonWeightInfo: WeightInfo;
+    }
+}
+
+/// The implementation is quite rude now but should be fine. We implement this fixed weight
+/// for each runtime. Obviously we can write a real benchmark later to use in the final
+/// runtime but it should never be lot so far from this.
+impl<T: frame_system::Config> WeightInfo for T {
+    fn disable_verifier() -> Weight {
+        T::DbWeight::get().writes(1_u64)
+    }
+
+    fn on_verify_disabled_verifier() -> Weight {
+        T::DbWeight::get().reads(1_u64)
+    }
+}

--- a/pallets/verifiers/src/lib.rs
+++ b/pallets/verifiers/src/lib.rs
@@ -67,12 +67,13 @@
 pub use pallet::*;
 
 pub use pallet_verifiers_macros::*;
+
+pub mod common;
 #[allow(missing_docs)]
 pub mod mock;
 mod tests;
 
 pub use hp_verifiers::WeightInfo;
-
 #[frame_support::pallet]
 pub mod pallet {
 
@@ -81,7 +82,11 @@ pub mod pallet {
     #![cfg(not(doc))]
 
     use codec::Encode;
-    use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*, Identity};
+    use frame_support::{
+        dispatch::{DispatchErrorWithPostInfo, DispatchResultWithPostInfo, PostDispatchInfo},
+        pallet_prelude::*,
+        Identity,
+    };
     use frame_system::pallet_prelude::*;
     use hp_poe::OnProofVerified;
     use sp_core::{hexdisplay::AsBytesRef, H256};
@@ -123,7 +128,7 @@ pub mod pallet {
 
     /// Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]
-    pub trait Config<I: 'static = ()>: frame_system::Config
+    pub trait Config<I: 'static = ()>: frame_system::Config + crate::common::Config
     where
         I: Verifier,
     {
@@ -182,6 +187,8 @@ pub mod pallet {
         InvalidVerificationKey,
         /// Provided an unregistered verification key hash.
         VerificationKeyNotFound,
+        /// Current Verifier Pallet is disabled.
+        DisabledVerifier,
     }
 
     impl<T, I> From<VerifyError> for Error<T, I> {
@@ -194,6 +201,13 @@ pub mod pallet {
             }
         }
     }
+
+    #[pallet::storage]
+    #[pallet::getter(fn disabled)]
+    pub type Disabled<T: Config<I>, I: 'static = ()>
+    where
+        I: Verifier,
+    = StorageValue<_, bool>;
 
     #[pallet::storage]
     #[pallet::getter(fn vks)]
@@ -229,6 +243,10 @@ pub mod pallet {
             I: Verifier,
         {
             log::trace!("Submitting proof");
+            ensure!(
+                !Self::disabled().unwrap_or_default(),
+                on_disable_error::<T, I>()
+            );
             let vk = match &vk_or_hash {
                 VkOrHash::Hash(h) => {
                     Vks::<T, I>::get(h).ok_or(Error::<T, I>::VerificationKeyNotFound)?
@@ -257,6 +275,29 @@ pub mod pallet {
             Vks::<T, I>::insert(hash, vk);
             Self::deposit_event(Event::VkRegistered { hash });
             Ok(().into())
+        }
+
+        /// Disable verifier.
+        #[pallet::call_index(2)]
+        #[pallet::weight(<T::CommonWeightInfo as crate::common::WeightInfo>::disable_verifier())]
+        pub fn disable(origin: OriginFor<T>, disabled: bool) -> DispatchResult {
+            log::trace!("Disable verifier: {disabled}");
+            // Just root can disable/enable the verifier
+            ensure_root(origin)?;
+
+            Disabled::<T, I>::put(disabled);
+            Ok(())
+        }
+    }
+
+    pub(crate) fn on_disable_error<T: Config<I>, I: Verifier>() -> DispatchErrorWithPostInfo {
+        use crate::common::WeightInfo;
+        DispatchErrorWithPostInfo {
+            post_info: PostDispatchInfo {
+                actual_weight: Some(T::CommonWeightInfo::on_verify_disabled_verifier()),
+                pays_fee: Pays::Yes,
+            },
+            error: Error::<T, I>::DisabledVerifier.into(),
         }
     }
 

--- a/pallets/verifiers/src/mock.rs
+++ b/pallets/verifiers/src/mock.rs
@@ -139,11 +139,23 @@ impl WeightInfo<FakeVerifier> for MockWeightInfo {
     }
 }
 
+pub struct MockCommonWeightInfo;
+impl crate::common::WeightInfo for MockCommonWeightInfo {
+    fn disable_verifier() -> Weight {
+        Weight::from_parts(1001, 1002)
+    }
+
+    fn on_verify_disabled_verifier() -> Weight {
+        Weight::from_parts(1003, 1004)
+    }
+}
+
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
     pub enum Test
     {
         System: frame_system,
+        CommonVerifiersPallet: crate::common,
         FakeVerifierPallet: fake_pallet,
         OnProofVerifiedMock: on_proof_verified,
     }
@@ -160,6 +172,10 @@ impl crate::Config<FakeVerifier> for Test {
     type RuntimeEvent = RuntimeEvent;
     type OnProofVerified = OnProofVerifiedMock;
     type WeightInfo = MockWeightInfo;
+}
+
+impl crate::common::Config for Test {
+    type CommonWeightInfo = MockCommonWeightInfo;
 }
 
 impl on_proof_verified::Config for Test {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -704,6 +704,10 @@ impl pallet_proxy::Config for Runtime {
     type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
+impl pallet_verifiers::common::Config for Runtime {
+    type CommonWeightInfo = Runtime;
+}
+
 impl pallet_verifiers::Config<pallet_fflonk_verifier::Fflonk> for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type OnProofVerified = Poe;
@@ -812,6 +816,7 @@ construct_runtime!(
         Vesting: pallet_vesting,
         VoterList: pallet_bags_list::<Instance1>,
         Proxy: pallet_proxy,
+        CommonVerifiers: pallet_verifiers::common,
     }
 );
 

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -772,6 +772,16 @@ mod use_correct_weights {
             crate::weights::pallet_staking::ZKVWeight::<Runtime>::bond()
         );
     }
+
+    #[test]
+    fn pallet_verifiers() {
+        use pallet_verifiers::common::WeightInfo;
+
+        assert_eq!(
+            <Runtime as pallet_verifiers::common::Config>::CommonWeightInfo::on_verify_disabled_verifier(),
+            <Runtime as pallet_verifiers::common::WeightInfo>::on_verify_disabled_verifier()
+        );
+    }
 }
 
 mod pallets_interact {

--- a/verifiers/fflonk/src/benchmarking.rs
+++ b/verifiers/fflonk/src/benchmarking.rs
@@ -115,6 +115,10 @@ mod mock {
         type WeightInfo = crate::FflonkWeight<()>;
     }
 
+    impl pallet_verifiers::common::Config for Test {
+        type CommonWeightInfo = Test;
+    }
+
     /// Build genesis storage according to the mock runtime.
     pub fn test_ext() -> sp_io::TestExternalities {
         let mut ext = sp_io::TestExternalities::from(

--- a/verifiers/groth16/src/benchmarking.rs
+++ b/verifiers/groth16/src/benchmarking.rs
@@ -146,6 +146,10 @@ mod mock {
         type WeightInfo = crate::Groth16Weight<()>;
     }
 
+    impl pallet_verifiers::common::Config for Test {
+        type CommonWeightInfo = Test;
+    }
+
     impl crate::Config for Test {
         const MAX_NUM_INPUTS: u32 = crate::MAX_NUM_INPUTS - 1;
     }

--- a/zombienet-tests/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.zndsl
+++ b/zombienet-tests/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.zndsl
@@ -1,0 +1,10 @@
+Description: Testing that a proof submission should pay both if it's ok or fails
+Network: ./network_defs/single_node.toml
+Creds: config
+
+alice: is up
+
+alice: reports node_roles is 4
+
+### Javascript test invocation
+alice: js-script ./js_scripts/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.js return is equal to 1 within 30 seconds

--- a/zombienet-tests/js_scripts/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.js
+++ b/zombienet-tests/js_scripts/0009-proof_on_disabled_verifier_should_pay_just_a_little_fee.js
@@ -1,0 +1,73 @@
+const MIN_PRICE = 1000000000;
+
+const ReturnCode = {
+    Ok: 1,
+    ErrProofVerificationFailed: 2,
+    ErrCannotDisable: 3,
+    ErrVerifiedOnDisable: 4,
+    ErrValidProofNotPay: 5,
+    ErrDisableProofTooCostly: 6,
+};
+
+const { init_api, submitProof, getBalance, receivedEvents, submitExtrinsic } = require('zkv-lib')
+const { PROOF, PUBS, VK } = require('./fflonk_data.js');
+
+// Call verify on a disable verifier should cost at most FACTOR times the cost of the proof.
+const FACTOR = 100;
+
+async function run(nodeName, networkInfo, _args) {
+    const api = await init_api(zombie, nodeName, networkInfo);
+
+    // Create a keyring instance
+    const keyring = new zombie.Keyring({ type: 'sr25519' });
+    const alice = keyring.addFromUri('//Alice');
+
+    let balanceAlice = await getBalance(alice);
+    console.log('Alice\'s balance: ' + balanceAlice.toHuman());
+
+    if (!receivedEvents(await submitProof(api.tx.settlementFFlonkPallet, alice, { 'Vk': VK }, PROOF, PUBS))) {
+        return ReturnCode.ErrProofVerificationFailed;
+    };
+
+    let newBalanceAlice = await getBalance(alice);
+    console.log('Alice\'s balance after valid proof: ' + newBalanceAlice.toHuman());
+
+    let paidBalanceOnVerify = balanceAlice.sub(newBalanceAlice);
+
+    console.log('Alice paid for a valid proof: ' + paidBalanceOnVerify);
+
+    const disableTx = api.tx.settlementFFlonkPallet.disable(true);
+    const sudoDisableTx = api.tx.sudo.sudo(disableTx)
+
+    if (!receivedEvents(await submitExtrinsic(sudoDisableTx, alice, BlockUntil.InBlock))) {
+        return ReturnCode.ErrCannotDisable;
+    };
+
+    balanceAlice = await getBalance(alice);
+    console.log('Alice\'s balance before verify a proof on disabled verifier: ' + balanceAlice.toHuman());
+
+    // This should fails
+    if (receivedEvents(await submitProof(api.tx.settlementFFlonkPallet, alice, { 'Vk': VK }, PROOF, PUBS))) {
+        return ReturnCode.ErrVerifiedOnDisable;
+    };
+
+    newBalanceAlice = await getBalance(alice);
+
+    console.log('Alice\'s balance after verify a proof on disabled verifier: ' + newBalanceAlice.toHuman());
+
+    let paidBalanceOnDisable = balanceAlice.sub(newBalanceAlice);
+
+    console.log('Alice paid for a disable verifier: ' + paidBalanceOnDisable);
+
+    if (paidBalanceOnDisable > paidBalanceOnVerify / FACTOR) {
+        console.log(`ERROR: Alice should pay at most ${FACTOR} times what she paid for a valid verify`);
+        return ReturnCode.ErrDisableProofTooCostly;
+    }
+    console.log(`INFO: Alice paid less than ${FACTOR} times`);
+
+    // Any return value different from 1 is considered an error
+    return ReturnCode.Ok;
+}
+
+module.exports = { run }
+


### PR DESCRIPTION
Rational: we need a way to handle issues related to verifiers that have bugs or wrongly weights that can cause chains attacks.

- Implement a storage variable for, eventually,  disabling a verifier.
- Just root can disable/enable a verifier.
- Verify on a disable verifier should cost just the check and not all the weight
-  Introduced a common pallet to handle the weights that are the same for all verifiers (enable/disable and pay for a verification on a disable verifier)

Future works:
- Introduce a verifier manager for all verifiers and eventually one for each verifier instead of use the hardcoded root user only (if we want to remove sudo).
- Write a benchmark for the common weights instead of use the hardcoded implementation.