### PR TITLE
Coverage with latest rust version

### DIFF
--- a/.github/workflows/CI-coverage.yml
+++ b/.github/workflows/CI-coverage.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   IMAGE_NAME: zencash/sc-ci-base
-  IMAGE_TAG: noble_rust-stable_20240611
+  IMAGE_TAG: noble_rust-stable_latest
   DOCKER_COMPOSE_CMD: "docker compose -f ${GITHUB_WORKSPACE}/ci/docker-compose.yml run --rm cargo-container"
   DOCKER_BUILD_DIR: /build
   DOCKER_CARGO_HOME: /tmp/.cargo
@@ -63,7 +63,7 @@ jobs:
             set -o pipefail \
             && cargo llvm-cov clean --workspace \
             && find . -name "*.profraw" -delete \
-            && cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info \
+            && cargo llvm-cov --all-features --workspace --exclude mainchain --lcov --output-path lcov.info \
             && cargo llvm-cov report --json --output-path coverage_report.json --summary-only \
             && cargo llvm-cov report | tee coverage_summary.txt
           '


### PR DESCRIPTION
Exclude mainchain from coverage to workaround the compiler issue and recover the use of the last toolchain.

Till https://github.com/rust-lang/rust/issues/125353 is not fixed we should exclude `mainchain` from our coverage that cause a compilation panic.

