### PR TITLE
Bump to 0.7.0 runtime version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13072,7 +13072,7 @@ dependencies = [
 
 [[package]]
 name = "zkv-runtime"
-version = "0.5.2"
+version = "0.7.0"
 dependencies = [
  "finality-grandpa",
  "frame-benchmarking",

--- a/node/src/reference_hardware.json
+++ b/node/src/reference_hardware.json
@@ -1,15 +1,15 @@
 [
     {
         "metric": "Blake2256",
-        "minimum": 619.64
+        "minimum": 990.0
     },
     {
         "metric": "Sr25519Verify",
-        "minimum": 0.227
+        "minimum": 0.790
     },
     {
         "metric": "MemCopy",
-        "minimum": 7820.0
+        "minimum": 15000.0
     },
     {
         "metric": "DiskSeqWrite",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkv-runtime"
-version = "0.5.2"
+version = "0.7.0"
 description = "zkVerify Mainchain Runtime."
 authors.workspace = true
 homepage = "https://github.com/HorizenLabs/zkVerify"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -146,7 +146,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // The version of the runtime specification. A full node will not attempt to use its native
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    spec_version: 6_000,
+    spec_version: 7_000,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Also update HW IO spec not changed till we check why the one in the reference machine are so smaller than the one on AWS